### PR TITLE
Fix the speed bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,13 +12,13 @@
             "console": "integratedTerminal",
             "justMyCode": true,
             "args": [
-                "--track-layout",        "l_shape",
-                "--lap-number",          "7",
+                "--track-layout",        "ellipse",
+                "--lap-number",          "10",
                 "--number-other-agents", "1",
                 "--simulation",
                 "--direct-lmpc",
                 "--animation",
-                "--random-other-agents"
+                // "--random-other-agents"
             ]
         }
     ]

--- a/car_racing/planner/lmpc.py
+++ b/car_racing/planner/lmpc.py
@@ -424,6 +424,9 @@ class LMPCRacingGame(PlannerBase):
     def trigger_overtaking(self):
         self._mode = LMPCRacingGame.Mode.OVERTAKE
 
+    def is_following(self):
+        return self._mode == LMPCRacingGame.Mode.FOLLOW
+
     def set_vehicles_track(self):
         """Set the self's track to the overtake planner"""
         if self.realtime_flag == False:

--- a/car_racing/planner/lmpc.py
+++ b/car_racing/planner/lmpc.py
@@ -520,6 +520,11 @@ class LMPCRacingGame(PlannerBase):
         x_track = np.array([5.0, 0, 0, 0, 0, 0]).reshape(X_DIM, 1)
         opti.subject_to(x[:, 0] == xcurv)
         # state/input constraints
+        if self.follow_vehicle is not None :
+            # x[4] is the s, x[5] is the ey
+            follow_vehicle_s = self.follow_vehicle.xcurv[4]
+            while follow_vehicle_s <= xcurv[4]: 
+                follow_vehicle_s += self.lap_length
         for i in range(self.lmpc_param.num_horizon):
             opti.subject_to(
                 x[:, i + 1]
@@ -535,12 +540,6 @@ class LMPCRacingGame(PlannerBase):
             # min and max of a
             opti.subject_to(-self.system_param.a_max <= u[1, i])
             opti.subject_to(u[1, i] <= self.system_param.a_max)
-            if self._mode == LMPCRacingGame.Mode.FOLLOW and self.follow_vehicle is not None :
-                # x[4] is the s, x[5] is the ey
-                follow_vehicle_s = self.follow_vehicle.xcurv[4]
-                while follow_vehicle_s <= xcurv[4]: 
-                    follow_vehicle_s += self.lap_length
-                opti.subject_to(x[4, i] <= follow_vehicle_s)
             # quadratic cost
             cost_mpc += ca.mtimes(
                 (x[:, i] - x_track).T,
@@ -558,6 +557,9 @@ class LMPCRacingGame(PlannerBase):
                     ca.mtimes(self.lmpc_param.matrix_dR, u[:, i] - u[:, i - 1]),
                 )
         # convex hull for LMPC
+        if self._mode == LMPCRacingGame.Mode.FOLLOW and self.follow_vehicle is not None :
+            # x[4] is the s, x[5] is the ey
+            opti.subject_to(x[4, self.lmpc_param.num_horizon] <= follow_vehicle_s)
         cost_mpc += ca.mtimes(
             (x[:, self.lmpc_param.num_horizon] - x_track).T,
             ca.mtimes(self.lmpc_param.matrix_Q, x[:, self.lmpc_param.num_horizon] - x_track),

--- a/car_racing/tests/overtake_planner_test.py
+++ b/car_racing/tests/overtake_planner_test.py
@@ -188,19 +188,22 @@ def racing_overtake(args, file_number):
                                 ego.lmpc_prediction = []
                                 ego.mpc_cbf_prediction = []
                                 simulator.sim(sim_time=time_lmpc, one_lap=True, one_lap_name="ego")
+                                # NOTE: at this lap, the ego is in following mode
+                                # NOTE: hence, DO NOT learn this lap
                                 # ego.ctrl_policy.add_trajectory(
                                 #     ego,
                                 #     iter,
                                 # )
                             else:
                                 if iter == 8: 
-                                    if isinstance(ego.ctrl_policy, LMPCRacingGame): 
-                                        ego.ctrl_policy.trigger_overtaking()
+                                    lmpc_controller.trigger_overtaking()
                                 simulator.sim(sim_time=time_lmpc, one_lap=True, one_lap_name="ego")
-                                # ego.ctrl_policy.add_trajectory(
-                                #     ego,
-                                #     iter,
-                                # )
+                                if not lmpc_controller.is_following(): 
+                                    # NOTE: only start learning DURING 
+                                    ego.ctrl_policy.add_trajectory(
+                                        ego,
+                                        iter,
+                                    )
                         else:
                             simulator.sim(sim_time=time_lmpc, one_lap=True, one_lap_name="ego")
                             ego.ctrl_policy.add_trajectory(

--- a/car_racing/tests/overtake_planner_test.py
+++ b/car_racing/tests/overtake_planner_test.py
@@ -10,8 +10,8 @@ from racing_env import *
 
 OTHER_CAR_SPEED = 1.0
 EGO_CAR_ACC_MAX = 0.7
-START_EY = -0.5
-START_S = 10.5
+START_EY = 0.0
+START_S = 4.5
 START_S_INTERVAL = 1.5
 START_EY_INTERVAL = 0.3
 
@@ -188,19 +188,19 @@ def racing_overtake(args, file_number):
                                 ego.lmpc_prediction = []
                                 ego.mpc_cbf_prediction = []
                                 simulator.sim(sim_time=time_lmpc, one_lap=True, one_lap_name="ego")
-                                ego.ctrl_policy.add_trajectory(
-                                    ego,
-                                    iter,
-                                )
+                                # ego.ctrl_policy.add_trajectory(
+                                #     ego,
+                                #     iter,
+                                # )
                             else:
                                 if iter == 8: 
                                     if isinstance(ego.ctrl_policy, LMPCRacingGame): 
                                         ego.ctrl_policy.trigger_overtaking()
                                 simulator.sim(sim_time=time_lmpc, one_lap=True, one_lap_name="ego")
-                                ego.ctrl_policy.add_trajectory(
-                                    ego,
-                                    iter,
-                                )
+                                # ego.ctrl_policy.add_trajectory(
+                                #     ego,
+                                #     iter,
+                                # )
                         else:
                             simulator.sim(sim_time=time_lmpc, one_lap=True, one_lap_name="ego")
                             ego.ctrl_policy.add_trajectory(
@@ -264,7 +264,7 @@ def racing_overtake(args, file_number):
                 simulator.animate(filename=file_name, ani_time=2000, racing_game=True)
 
 
-def set_up_ego(timestep, track):
+def set_up_ego(timestep: float, track: ClosedTrack):
     ego = OffboardDynamicBicycleModel(name="ego", param=CarParam(edgecolor="black"), system_param = SystemParam(a_max=EGO_CAR_ACC_MAX))
     ego.set_timestep(timestep)
     # run the pid controller for the first lap to collect data


### PR DESCRIPTION
Fix the bug that the speed is not fast enough in overtaking mode. 

## How

The reason seems to be: 

1. During the following stages, the learning MPC is still learning.
2. However, in the following stage, the vehicle moves slow simply because of the front vehicle's blocking
3. But, the learning MPC doesn't know that! It now **learns** the vehicle should not move fast
4. Hence, in the following laps, the vehicle proactively reduces its speed. 

### Solution

Hence, we **turn off** the learning during the following stages! 

### How to turn on or off the learning: 

To learn from one lap: 

```py
ctrl_policy.add_trajectory(
    ego, # the ego vehicle
    iter,  # this lap's index
 )
```

Hence, as long as we don't learn the lap where the vehicle is in the following mode, the speed shall remain normal. 